### PR TITLE
Modify donation javascript to count the donations since the start of the month

### DIFF
--- a/static/js/donationfunds.js
+++ b/static/js/donationfunds.js
@@ -1,2 +1,29 @@
-$(function(){if($('.donationGoal').length>0){$('.donationGoal').each(function(){var goalObj=$(this);var address=goalObj.attr('data-address');var goal=parseInt(goalObj.attr('data-goal'));$.get('https://vtc.blkidx.org/addressBalance/'+address,function(data){var vtcBalance=Math.round(parseInt(data)/1000000);vtcBalance/=100;var goalPercentage=100;if(!isNaN(goal)){goalPercentage=Math.round(vtcBalance/goal*100);if(goalPercentage>100)goalPercentage=100}
-goalObj.find('.progress-bar').css('width',goalPercentage+'%');goalObj.find('.progress-bar').attr('aria-valuenow',goalPercentage);goalObj.find('.donationAmount').text(vtcBalance)})})}})
+$(function () {
+    if ($('.donationGoal').length > 0) {
+        $('.donationGoal').each(function () {
+            var goalObj = $(this); var address = goalObj.attr('data-address'); 
+            var goal = parseInt(goalObj.attr('data-goal')); 
+
+            var currentDate = new Date();
+            var monthStart = Date.UTC(currentDate.getUTCFullYear(), currentDate.getUTCMonth());
+            var unixTime = Math.floor(monthStart / 1000);
+
+            $.get('https://vtc.blkidx.org/addressTxosSince/' + unixTime + '/' + address, function (data) {
+                var vtcBalance = 0;
+                for(var i in data) {
+                    vtcBalance += data[i]['value'];
+                }
+                vtcBalance = Math.round(vtcBalance / 1000000); 
+                vtcBalance /= 100; 
+                var goalPercentage = 100;
+                if (!isNaN(goal)) { 
+                    goalPercentage = Math.round(vtcBalance / goal * 100); 
+                    if (goalPercentage > 100) goalPercentage = 100 
+                }
+                goalObj.find('.progress-bar').css('width', goalPercentage + '%'); 
+                goalObj.find('.progress-bar').attr('aria-valuenow', goalPercentage); 
+                goalObj.find('.donationAmount').text(vtcBalance)
+            })
+        })
+    }
+})


### PR DESCRIPTION
Previously manually sweeping the wallet was required to reset the monthly donation totals but due to gertjaap/blockchain-indexer#2 we can now get TXOs via timestamp. The modification to the javascript adds up the total donated since the start of the month.